### PR TITLE
remove `OpenAIModel`

### DIFF
--- a/run_benchmark.py
+++ b/run_benchmark.py
@@ -1,6 +1,6 @@
 # python run_benchmark.py --model_name=gpt-4o-mini --dataset_path=output.json
 
-from weave_utils.models import LiteLLMModel, MajorityVoteModel, OpenAIModel
+from weave_utils.models import LiteLLMModel, MajorityVoteModel
 from weave_utils.scorers import eval_majority_vote, eval_multi_choice
 import json
 import weave


### PR DESCRIPTION
The `OpenAIModel` is not available and thus running `python run_benchmark.py ....` fails.